### PR TITLE
pytorch-lightning 1.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   imports:
     - pytorch_lightning
   requires:
-    - python >=3.7,<3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
+    - python
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - pip check
 
 about:
-  home: https://pypi.org/project/pytorch-lightning/
+  home: https://lightning.ai/
   summary: PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate.
   license: Apache-2.0
   license_family: Apache

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "1.9.0" %}
+{% set version = "1.9.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,46 +7,49 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5b75fe936d16ef86dae22ea1cb0a73db281605cade682c0ef44e6508a99a0b37
+  sha256: 479164caea190d49ee2a218eef7e001888be56db912b417639b047e8f9ca8a07
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
     - pip
-    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
+    - python >=3.7,<3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
     - packaging >=17.1
     - numpy >=1.17.2
     - pyyaml >=5.4
     - pytorch >=1.10.0
     - tqdm >=4.57.0
-    - fsspec[http] >2021.06.0
+    - fsspec >2021.06.0
     - torchmetrics >=0.7.0
     - typing-extensions >=4.0.0
-    - lightning-utilities >=0.4.2
+    - lightning-utilities >=0.6.0.post0
 
 test:
   imports:
     - pytorch_lightning
+  requires:
+    - python >=3.7,<3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
+    - pip
   commands:
     - pip check
-  requires:
-    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
-    - pip
 
 about:
   home: https://pypi.org/project/pytorch-lightning/
   summary: PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   description: |
     Lightning is a way to organize your PyTorch code to decouple the science code from the engineering.
-     It's more of a style-guide than a framework.
+    It's more of a style-guide than a framework.
 
     In Lightning, you organize your code into 3 distinct categories:
 
@@ -55,15 +58,13 @@ about:
     3. Non-essential research code (logging, etc. this goes in Callbacks).
 
     Although your research/production project might start simple, once you add things like GPU AND TPU training,
-     16-bit precision, etc, you end up spending more time engineering than researching.
-     Lightning automates AND rigorously tests those parts for you.
+    16-bit precision, etc, you end up spending more time engineering than researching.
+    Lightning automates AND rigorously tests those parts for you.
 
     Overall, Lightning guarantees rigorously tested, correct, modern best practices for the automated parts.
 
-    Documentation
-    -------------
-    - https://pytorch-lightning.readthedocs.io/en/latest
-    - https://pytorch-lightning.readthedocs.io/en/stable
+  doc_url: https://pytorch-lightning.readthedocs.io
+  dev_url: https://github.com/Lightning-AI/lightning
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # TODO: this upper bound is because of PyTorch issue with dataclass
+  skip: True  # [py<37 or py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
@@ -21,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7,<3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
+    - python
     - packaging >=17.1
     - numpy >=1.17.2
     - pyyaml >=5.4


### PR DESCRIPTION
Changelog: https://github.com/Lightning-AI/lightning/releases
License: https://github.com/Lightning-AI/lightning/blob/1.9.3/LICENSE
Requirements:
- https://github.com/Lightning-AI/lightning/blob/1.9.3/pyproject.toml
- https://github.com/Lightning-AI/lightning/blob/1.9.3/requirements.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.3/requirements/pytorch/base.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.3/setup.py

Actions:
1. Remove `noarch`
2. Skip `py<37` and `py>311`
3. Add `--no-deps`
4. Remove `python` pinnings in `host` and `run`
5. Add missing `setuptools` and `wheel` to `host`
6. Fix the `fsspec` package name
7. Update pinning for `lightning-utilities >=0.6.0.post0`
8. Add `license_family`
9. Fix indentation in the `description`
10. Add doc & dev urls