### PR TITLE
update to v2.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+aggregate_check: false
+upload_channels:
+  - boldorider4-test-channel
+channels:
+  - boldorider4-test-channel

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - boldorider4-test-channel
-channels:
-  - boldorider4-test-channel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,5 +75,3 @@ extra:
     - williamFalcon
     - borda
     - carmocca
-  skip-lints:
-    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - numpy >=1.17.2
     - pyyaml >=5.4
     - pytorch >=1.11.0
-    - future >=0.17.1
     - tqdm >=4.57.0
     - fsspec >2021.06.1
     - torchmetrics >=0.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
   skip: True  # [py<37 or py>310]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b37a3677a65cda920260de3899ea9dfdd221b0a2d838a0439e31bd927efa61f4
+  sha256: 3b12080f6b3205cc7aaa42a1e08b221007b999a63c0032d0090f29ff8d0d7221
 
 build:
   number: 0
@@ -30,11 +30,10 @@ requirements:
     - pytorch >=1.11.0
     - future >=0.17.1
     - tqdm >=4.57.0
-    - fsspec >2021.06.0
+    - fsspec >2021.06.1
     - torchmetrics >=0.7.0
     - typing-extensions >=4.0.0
     - lightning-utilities >=0.7.0
-    - requests
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  # skipping py311 for win and linux-ppc64le because for now dep pytorch is not supported on such platformsyou 
+  # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
   skip: True  # [py>310 and (linux and ppc64le)]
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - packaging >=17.1
     - numpy >=1.17.2
     - pyyaml >=5.4
-    - pytorch              # [not (osx and x86_64)]
-    - pytorch >1.9,<1.12.0 # [osx and x86_64]
+    - pytorch >=1.11.0
     - future >=0.17.1
     - tqdm >=4.57.0
-    - fsspec >2021.06.1
+    - fsspec >2021.06.0
     - torchmetrics >=0.7.0
     - typing-extensions >=4.0.0
     - lightning-utilities >=0.7.0
+    - requests
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,3 +74,5 @@ extra:
     - williamFalcon
     - borda
     - carmocca
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "1.9.5" %}
+{% set version = "2.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 925fe7b80ddf04859fa385aa493b260be4000b11a2f22447afb4a932d1f07d26
+  sha256: b37a3677a65cda920260de3899ea9dfdd221b0a2d838a0439e31bd927efa61f4
 
 build:
   number: 0
@@ -26,12 +26,13 @@ requirements:
     - packaging >=17.1
     - numpy >=1.17.2
     - pyyaml >=5.4
-    - pytorch >=1.10.0
+    - pytorch >=1.11.0
+    - future >=0.17.1
     - tqdm >=4.57.0
-    - fsspec >2021.06.0
+    - fsspec >2021.06.1
     - torchmetrics >=0.7.0
     - typing-extensions >=4.0.0
-    - lightning-utilities >=0.6.0.post0
+    - lightning-utilities >=0.7.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - packaging >=17.1
     - numpy >=1.17.2
     - pyyaml >=5.4
-    - pytorch >=1.11.0
+    - pytorch              # [not (osx and x86_64)]
+    - pytorch >1.9,<1.12.0 # [osx and x86_64]
     - future >=0.17.1
     - tqdm >=4.57.0
     - fsspec >2021.06.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,10 @@ source:
 
 build:
   number: 0
-  # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
-  skip: True  # [py<37 or py>310]
+  # the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
+  skip: True  # [py<37]
+  # skipping py311 for win and linux-ppc64le because for now dep pytorch is not supported on such platformsyou 
+  skip: True  # [py>310 and (win or (linux and ppc64le))]
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,9 @@ source:
 
 build:
   number: 0
-  # the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
   skip: True  # [py<37]
   # skipping py311 for win and linux-ppc64le because for now dep pytorch is not supported on such platformsyou 
-  skip: True  # [py>310 and (win or (linux and ppc64le))]
+  skip: True  # [py>310 and (linux and ppc64le)]
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
- [x] checked upstream project for requirements
- [x] checked license file
- [x] added PyTorch restriction for osx-64 to avoid openmp compatibility issue
- [x] building against PyTorch < 2.0.0, which means we may have to rebuild once
       PyTorch 2.0.0 is available