### PR TITLE
pytorch-lightning 1.9.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 1
   # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
-  skip: True  # [py<37 or py>311]
+  skip: True  # [py<37 or py>310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "1.9.3" %}
+{% set version = "1.9.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 479164caea190d49ee2a218eef7e001888be56db912b417639b047e8f9ca8a07
+  sha256: 925fe7b80ddf04859fa385aa493b260be4000b11a2f22447afb4a932d1f07d26
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 925fe7b80ddf04859fa385aa493b260be4000b11a2f22447afb4a932d1f07d26
 
 build:
-  number: 1
+  number: 0
   # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
   skip: True  # [py<37 or py>310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -72,5 +72,3 @@ extra:
     - williamFalcon
     - borda
     - carmocca
-  skip-lints:
-    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 1
   # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
-  skip: True  # [py<37 or py>311)]
+  skip: True  # [py<37 or py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 1
-  skip: True  # [py<37]
+  # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
+  # pytorch <=1.13.1 hasn't python 3.11 support on win
+  skip: True  # [py<37 or (((linux and ppc64le) or win) and py==311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,9 @@ source:
   sha256: 479164caea190d49ee2a218eef7e001888be56db912b417639b047e8f9ca8a07
 
 build:
-  number: 0
-  # TODO: this upper bound is because of PyTorch issue with dataclass
-  skip: True  # [py<37 or py>311]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 1
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -72,3 +71,5 @@ extra:
     - williamFalcon
     - borda
     - carmocca
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,8 @@ source:
 
 build:
   number: 1
-  # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  # pytorch <=1.13.1 hasn't python 3.11 support on win
-  skip: True  # [py<37 or (((linux and ppc64le) or win) and py==311)]
+  # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
+  skip: True  # [py<37 or py>311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/Lightning-AI/lightning/releases
License: https://github.com/Lightning-AI/lightning/blob/1.9.5/LICENSE
Requirements:
- https://github.com/Lightning-AI/lightning/blob/1.9.5/pyproject.toml
- https://github.com/Lightning-AI/lightning/blob/1.9.5/requirements.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.5/requirements/pytorch/base.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.5/setup.py

Actions:
1. Skip `py>310` because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
2. Add `--no-build-isolation`


Notes:
- we update it for preventing incompatibilities with Pytorch and downstream packages, and also for `gluonts` https://github.com/AnacondaRecipes/gluon-ts-feedstock/pull/2
 