### PR TITLE
rebuild for py311

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/torchmetrics-feedstock/pr9/1f11a41

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/torchmetrics-feedstock/pr9/1f11a41

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 1
   skip: True  # [py<37]
+  # missing torchmetrics for linux-64 py312
+  skip: True  # [linux and x86_64 and py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,8 @@ source:
   sha256: 925fe7b80ddf04859fa385aa493b260be4000b11a2f22447afb4a932d1f07d26
 
 build:
-  number: 0
-  # TODO: the upper bound is because of PyTorch issue with dataclass, see https://github.com/Lightning-AI/lightning/issues/15614
-  skip: True  # [py<37 or py>310]
+  number: 1
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 1
   skip: True  # [py<37]
-  # missing torchmetrics for linux-64 py312
-  skip: True  # [linux and x86_64 and py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
pytorch-lightning 1.9.5 rebuild for py311

**Destination channel:** defaults

### Links

- [PKG-5034]
- [Upstream repository](https://github.com/Lightning-AI/pytorch-lightning/tree/1.9.5)



[PKG-5034]: https://anaconda.atlassian.net/browse/PKG-5034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ