### PR TITLE
pytorch-lightning 2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
+    # Dependencies from pytorch-lightning/requirements/pytorch/base.txt
     - python
     - packaging >=20.0
     - numpy >=1.17.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "2.0.3" %}
+{% set version = "2.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b12080f6b3205cc7aaa42a1e08b221007b999a63c0032d0090f29ff8d0d7221
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 89caf90e3543b314508493f26e0eca8d5e10e43e3d9e6c143acd8ddceb584ce2
 
 build:
   number: 0
   skip: True  # [py<37]
-  # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
-  skip: True  # [py>310 and (linux and ppc64le)]
-  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -24,21 +22,20 @@ requirements:
     - wheel
   run:
     - python
-    - packaging >=17.1
-    - numpy >=1.17.2
-    - pyyaml >=5.4
-    - pytorch >=1.11.0
-    - tqdm >=4.57.0
-    - fsspec >2021.06.1
-    - torchmetrics >=0.7.0
-    - typing-extensions >=4.0.0
-    - lightning-utilities >=0.7.0
+    - packaging >=20.0,<=23.1
+    - numpy >=1.17.2,<1.27.0
+    - pyyaml >=5.4,<6.1.0
+    - pytorch >=2.0.0,<2.4.0
+    - tqdm >=4.57.0,<4.67.0
+    - fsspec >2022.5.0,<2024.4.0
+    - torchmetrics >=0.7.0,<1.3.0
+    - typing-extensions >=4.4.0,<4.10.0
+    - lightning-utilities >=0.8.0,<0.12.0
 
 test:
   imports:
     - pytorch_lightning
   requires:
-    - python
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - packaging >=20.0s
+    - packaging >=20.0
     - numpy >=1.17.2
     - pyyaml >=5.4
     - pytorch >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pyyaml >=5.4
     - pytorch >=2.0.0
     - tqdm >=4.57.0
-    - fsspec >2022.5.0
+    - fsspec >=2022.5.0
     - torchmetrics >=0.7.0
     - typing-extensions >=4.4.0
     - lightning-utilities >=0.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 89caf90e3543b314508493f26e0eca8d5e10e43e3d9e6c143acd8ddceb584ce2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 89caf90e3543b314508493f26e0eca8d5e10e43e3d9e6c143acd8ddceb584ce2
 
 build:
   number: 0
@@ -22,15 +22,15 @@ requirements:
     - wheel
   run:
     - python
-    - packaging >=20.0,<=23.1
-    - numpy >=1.17.2,<1.27.0
-    - pyyaml >=5.4,<6.1.0
-    - pytorch >=2.0.0,<2.4.0
-    - tqdm >=4.57.0,<4.67.0
-    - fsspec >2022.5.0,<2024.4.0
-    - torchmetrics >=0.7.0,<1.3.0
-    - typing-extensions >=4.4.0,<4.10.0
-    - lightning-utilities >=0.8.0,<0.12.0
+    - packaging >=20.0s
+    - numpy >=1.17.2
+    - pyyaml >=5.4
+    - pytorch >=2.0.0
+    - tqdm >=4.57.0
+    - fsspec >2022.5.0
+    - torchmetrics >=0.7.0
+    - typing-extensions >=4.4.0
+    - lightning-utilities >=0.8.0
 
 test:
   imports:


### PR DESCRIPTION

**Destination channel:** main

### Links

- [PKG-2731](https://anaconda.atlassian.net/browse/PKG-2731) 
- [Upstream repository](https://github.com/Lightning-AI/pytorch-lightning/tree/2.3.0)
- Requirements:
  - https://github.com/Lightning-AI/pytorch-lightning/blob/2.3.0/pyproject.toml
  - https://github.com/Lightning-AI/pytorch-lightning/blob/2.3.0/requirements.txt
  - https://github.com/Lightning-AI/pytorch-lightning/blob/2.3.0/requirements/pytorch/base.txt
  - 

### Explanation of changes:

- Update runtime pinnings

### Notes:

- Updating because of the `pytorch 2.3.0` release


[PKG-2731]: https://anaconda.atlassian.net/browse/PKG-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ