### PR TITLE
pytorch-lightning 2.0.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 89caf90e3543b314508493f26e0eca8d5e10e43e3d9e6c143acd8ddceb584ce2
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
pytorch-lightning 2.0.3 

**Destination channel:** Defaults

### Links

- [PKG-6420]
- dev_url:        https://github.com/Lightning-AI/lightning/tree/2.0.3

### Explanation of changes:

- Rebuild to get missing `py312` artifact for `linux-64`


[PKG-6420]: https://anaconda.atlassian.net/browse/PKG-6420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ