### PR TITLE
pytorch-lightning 2.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3b12080f6b3205cc7aaa42a1e08b221007b999a63c0032d0090f29ff8d0d7221
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
   # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
   skip: True  # [py>310 and (linux and ppc64le)]


### PR DESCRIPTION
pytorch-lightning 2.0.3

**Destination channel:** defaults

### Links

- [PKG-6420](https://anaconda.atlassian.net/browse/PKG-6420)

### Explanation of changes:

- Rebuild to get missing `py312` artifact for `linux-64`


[PKG-6420]: https://anaconda.atlassian.net/browse/PKG-6420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ