### PR TITLE
v2.5.0.post0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "2.3.0" %}
+{% set version = "2.5.0.post0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 89caf90e3543b314508493f26e0eca8d5e10e43e3d9e6c143acd8ddceb584ce2
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 347235bf8573b4ebcf507a0dd755fcb9ce58c420c77220a9756a6edca0418532
 
 build:
   number: 0
@@ -24,14 +24,13 @@ requirements:
     # Dependencies from pytorch-lightning/requirements/pytorch/base.txt
     - python
     - packaging >=20.0
-    - numpy >=1.17.2
     - pyyaml >=5.4
-    - pytorch >=2.0.0
+    - pytorch >=2.1.0
     - tqdm >=4.57.0
     - fsspec >=2022.5.0
     - torchmetrics >=0.7.0
     - typing-extensions >=4.4.0
-    - lightning-utilities >=0.8.0
+    - lightning-utilities >=0.10.0
 
 test:
   imports:


### PR DESCRIPTION
pytorch-lightning v2.5.0.post0

**Destination channel:** defaults

### Links

- [PKG-7171](https://anaconda.atlassian.net/browse/PKG-7171) 
- [Upstream repository](https://github.com/Lightning-AI/pytorch-lightning/tree/2.5.0.post0)
- [Upstream changelog/diff](https://github.com/Lightning-AI/pytorch-lightning/tree/2.5.0.post0)
- [requirements](https://github.com/Lightning-AI/pytorch-lightning/blob/2.5.0.post0/requirements/pytorch/base.txt) 

### Explanation of changes:

- Bump version and SHA
- Update dependency pinnings
- Add 3.13 support
- Change minimum to [3.9 ](https://github.com/Lightning-AI/pytorch-lightning/blob/2.5.0.post0/pyproject.toml#L47)


[PKG-7171]: https://anaconda.atlassian.net/browse/PKG-7171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ